### PR TITLE
Hotfix that de-normalises some group data into the tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "tagman",
-    version = "0.2.0",
+    version = "0.2.1",
     author = "ReThought Ltd & UKTV",
     author_email = "code@rethought-solutions.com",
     url = "https://github.com/UKTV/tagman.git",

--- a/src/runtests.py
+++ b/src/runtests.py
@@ -15,7 +15,7 @@ def main():
                                'PASSWORD': '',
                                'HOST': '',
                                'PORT': ''}},
-        NOSE_ARGS=['--with-xunit', '-s'],
+        NOSE_ARGS=['--with-xunit', '-s', '-v'],
     )
 
     call_command('test', 'tagman')

--- a/src/tagman/migrations/0005_auto__add_field_tag_group_name__add_field_tag_group_slug__add_field_ta.py
+++ b/src/tagman/migrations/0005_auto__add_field_tag_group_name__add_field_tag_group_slug__add_field_ta.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Tag.group_name'
+        db.add_column('tagman_tag', 'group_name',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=100, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Tag.group_slug'
+        db.add_column('tagman_tag', 'group_slug',
+                      self.gf('django.db.models.fields.SlugField')(default='', max_length=100, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Tag.group_is_system'
+        db.add_column('tagman_tag', 'group_is_system',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Tag.group_name'
+        db.delete_column('tagman_tag', 'group_name')
+
+        # Deleting field 'Tag.group_slug'
+        db.delete_column('tagman_tag', 'group_slug')
+
+        # Deleting field 'Tag.group_is_system'
+        db.delete_column('tagman_tag', 'group_is_system')
+
+
+    models = {
+        'tagman.tag': {
+            'Meta': {'unique_together': "(('name', 'group'),)", 'object_name': 'Tag'},
+            'archived': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tagman.TagGroup']"}),
+            'group_is_system': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'group_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'group_slug': ('django.db.models.fields.SlugField', [], {'default': "''", 'max_length': '100', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'default': "''", 'max_length': '100'})
+        },
+        'tagman.taggroup': {
+            'Meta': {'object_name': 'TagGroup'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'default': "''", 'max_length': '100'}),
+            'system': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        }
+    }
+
+    complete_apps = ['tagman']

--- a/src/tagman/migrations/0006_datamigration_denormalised_group.py
+++ b/src/tagman/migrations/0006_datamigration_denormalised_group.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from south.db import db
+from south.v2 import SchemaMigration
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Tag.group_name'
+        if not db.dry_run:
+            for tag in orm.Tag.objects.all():
+                group = orm.TagGroup.objects.get(id=tag.group_id)
+                prefix = "*" if group.system else ""
+                tag.group_name = "{}{}".format(prefix, group.name)
+                tag.group_slug = str(group.slug)
+                tag.group_is_system = group.system
+                tag.save()
+
+    def backwards(self, orm):
+        raise RuntimeError("This migration is not reversible")
+
+    models = {
+        'tagman.tag': {
+            'Meta': {'unique_together': "(('name', 'group'),)", 'object_name': 'Tag'},
+            'archived': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tagman.TagGroup']"}),
+            'group_is_system': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'group_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'group_slug': ('django.db.models.fields.SlugField', [], {'default': "''", 'max_length': '100', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'default': "''", 'max_length': '100'})
+        },
+        'tagman.taggroup': {
+            'Meta': {'object_name': 'TagGroup'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'default': "''", 'max_length': '100'}),
+            'system': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        }
+    }
+
+    complete_apps = ['tagman']

--- a/src/tagman/tests/test_models.py
+++ b/src/tagman/tests/test_models.py
@@ -28,6 +28,79 @@ class TestTags(TestCase):
     def test_create_group(self):
         self.assertIsNotNone(self.group.pk)
 
+    def test_group_name(self):
+        """
+        Test that the group name is correctly saved on tag
+
+        This is inserted at time of re-factoring code to de-normalise
+        group name into Tag.group_name
+        """
+        self.assertEquals(self.tag1.group_name, self.group.name)
+
+    def test_group_name_change(self):
+        """
+        Test that group name re-set on group change for tag
+
+        Confirms that de-normalisation works when group changes
+        """
+        self.assertEquals(self.tag1.group_name, self.group.name)
+        self.tag1.group = self.groupb
+        self.tag1.save()
+        self.assertEquals(self.tag1.group_name, self.groupb.name)
+
+    def test_group_slug(self):
+        """
+        Test that the group slug is correctly saved on tag
+
+        This is inserted at time of re-factoring code to de-normalise
+        group slug into Tag.group_slug
+        """
+        self.assertEquals(self.tag1.group_slug, self.group.slug)
+
+    def test_group_slug_change(self):
+        """
+        Test that group slug re-set on group change for tag
+
+        Confirms that de-normalisation works when group changes
+        """
+        self.assertEquals(self.tag1.group_slug, self.group.slug)
+        self.tag1.group = self.groupb
+        self.tag1.save()
+        self.assertEquals(self.tag1.group_slug, self.groupb.slug)
+
+    def test_unicode(self):
+        """
+        Does the tag represent itself correctly when stringified
+        """
+        self.assertEquals(str(self.tag1), "test-group:test-tag1")
+
+    def test_unicode_system_tag(self):
+        tag = Tag(group=self.groupc, name="foo")
+        tag.save()
+        self.assertEquals(str(tag), "*system-group:foo")
+
+    def test_repr_system_tag(self):
+        tag = Tag(group=self.groupc, name="foo")
+        tag.save()
+        self.assertEquals(repr(tag), "system-group:foo")
+
+    def test_repr(self):
+        """
+        Does the tag represent itself correctly
+        """
+        self.assertEquals(repr(self.tag1), "test-group:test-tag1")
+
+    def test_denormalised_system_flag(self):
+        """
+        Does tag reflect its group's system flag
+        """
+        tag = Tag(group=self.groupc, name="foo")
+        tag.save()
+        self.assertFalse(self.tag1.group_is_system)
+        self.assertFalse(self.tag1.system)
+        self.assertTrue(tag.group_is_system)
+        self.assertTrue(tag.system)
+
     def test_add_tag_to_item(self):
         [self.item.tags.add(tag) for tag in self.tags]
         self.assertTrue([tag for tag in self.item.tags.all()


### PR DESCRIPTION
Prevents thousands of database queries when rendering tag strings.
Data migration to populate the new fields.
